### PR TITLE
Change IMG file structure for GH Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
           <h1 id="proj">My Projects</h1>
           <div class="project-tile">
             <h3>Travel Tracker</h3>
-            <img id="tracker-thumb" src="/img/Screen Shot 2020-08-19 at 7.50.56 PM.png"></img>
+            <img id="tracker-thumb" src="img/Screen Shot 2020-08-19 at 7.50.56 PM.png"></img>
            <p><b>Production Link:</b> https://josh-everett01.github.io/travel_tracker/</p>
            <p><b>Repositor Link:</b> https://github.com/josh-everett01/travel_tracker</p>
        </div>


### PR DESCRIPTION
This commit makes a change to the IMG file for the thumbnail in the projects section. The error was causing the image to display incorrectly. This change should correct this issue.